### PR TITLE
fix DiscographyNotFound exception and update README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,15 +23,17 @@ Installing
 Via pip
 
 .. code-block:: bash
-	$ pip install pygalume
+
+    $ pip install pygalume
 
 
 Clone this project and install via setup.py
 
 .. code-block:: bash
-	$ git clone git@github.com:dunderlabs/pygalume.git
-	$ cd pygalume/
-	$ python setup.py install
+
+    $ git clone git@github.com:dunderlabs/pygalume.git
+    $ cd pygalume/
+    $ python setup.py install
 
 
 Usage example
@@ -39,38 +41,50 @@ Usage example
 
 Here you can see pygalume in action. How to get a lyric from your favorite artist?
 
+  Pygalyme works offline for those lyrics you had already searched for.
+ 
 Note: if the artist's name or music have more than one word, wrap it with double quotes.
 
 .. code-block:: bash
 
-	$ pygalume -a Sia -m "Bird set free"
+    $ pygalume -a Sia -m "Bird set free"
 
 
 How to get the discography?
 
 .. code-block:: bash
 
-	$ pygalume -a Sia -d
+    $ pygalume -a Sia -d
 
 
 How to get songs name from an album?
 
 .. code-block:: bash
 
-	$ pygalume -a Sia --al "This Is Acting"
+    $ pygalume -a Sia --al "This Is Acting"
 
 
 How to list all songs in cache?
 
 .. code-block:: bash
 
-	$ pygalume --lc # or
-	$ pygalume --list-cache
+    $ pygalume --lc # or
+    $ pygalume --list-cache
 
 
 How to clear all songs in cache?
 
 .. code-block:: bash
 
-	$ pygalume --cc # or
-	$ pygalume --clear-cache
+    $ pygalume --cc # or
+    $ pygalume --clear-cache
+
+
+Development
+-------------
+
+Running unit tests:
+
+.. code-block:: bash
+
+    $ python setup test

--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ Usage example
 
 Here you can see pygalume in action. How to get a lyric from your favorite artist?
 
-  Pygalyme works offline for those lyrics you had already searched for.
+  Pygalume works offline for those lyrics you had already searched for.
  
 Note: if the artist's name or music have more than one word, wrap it with double quotes.
 

--- a/pygalume/controller/database.py
+++ b/pygalume/controller/database.py
@@ -37,6 +37,6 @@ class DataBase():
         lyrics.save()
 
     def getCachedSongs(self):
-        lyrics = Lyrics.select()
+        lyrics = Lyrics.select().order_by(Lyrics.artist)
 
         return lyrics

--- a/pygalume/pygalume.py
+++ b/pygalume/pygalume.py
@@ -1,7 +1,7 @@
 import argparse
 import os
 from .controller.factory import Factory
-from .myexceptions import MusicNotFound, ArtistNotFound
+from .myexceptions import MusicNotFound, ArtistNotFound, DiscographyNotFound
 
 
 factory = Factory()
@@ -181,9 +181,12 @@ def getDiscography(artist):
 
 
 def getSongs(artist, album):
-    data = factory.getSongs(artist, album)
-    for music in data:
-        print(music)
+    try:
+        data = factory.getSongs(artist, album)
+        for music in data:
+            print(music)
+    except DiscographyNotFound:
+        print('Discography not found!')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When a album name that did not exists is given, raise an error.

Fixed!

```
[delete@vostro:~]$ pygalume -a "Three Days Grace" --al "blabla"
Traceback (most recent call last):
  File "/usr/bin/pygalume", line 6, in <module>
    pygalume.main()
  File "/usr/lib/python3.5/site-packages/pygalume/pygalume.py", line 120, in main
    getSongs(artist, album)
  File "/usr/lib/python3.5/site-packages/pygalume/pygalume.py", line 184, in getSongs
    data = factory.getSongs(artist, album)
  File "/usr/lib/python3.5/site-packages/pygalume/controller/factory.py", line 40, in getSongs
    return self._api.getSongs(artist, album)
  File "/usr/lib/python3.5/site-packages/pygalume/controller/api.py", line 90, in getSongs
    raise DiscographyNotFound
pygalume.myexceptions.DiscographyNotFound
```
